### PR TITLE
Update README with NSB 8 note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # NServiceBus.Metrics.ServiceControl.Msmq
+
 Native Queue Length reporting to ServiceControl Monitoring for endpoints running on the MSMQ transport
+
+## Prerequisites
+
+NServiceBus.Metrics.ServiceControl.Msmq requires the .NET Framework and can only be used with NServiceBus 8 and below.


### PR DESCRIPTION
This PR adds a note to the README that should explain why there won't be an NSB 9 version.